### PR TITLE
Removing nft type version and enum on nft type.   A value for nftType…

### DIFF
--- a/XLS-24d/xls-24d-reference.json
+++ b/XLS-24d/xls-24d-reference.json
@@ -32,17 +32,6 @@
             "type": "string"
         },
         "nftType": {
-            "type": "string",
-            "enum": [
-                "image",
-                "animation",
-                "video",
-                "audio",
-                "document",
-                "other"
-            ]
-        },
-        "nftTypeVersion": {
             "type": "string"
         },
         "name": {


### PR DESCRIPTION
… will contain the version,  such as art.v0